### PR TITLE
[FEATURE] Disable uncaching in the Install Tool

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,19 +3,21 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
-foreach ($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] as $configurationName => $configuration) {
-    if (is_a($configuration['backend'], \TYPO3\CMS\Core\Cache\Backend\PhpCapableBackendInterface::class, true)) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
-            = \TYPO3\CMS\Core\Cache\Backend\NullBackend::class;
-    } elseif (is_a($configuration['frontend'], \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class, true)) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
-            = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['options']);
-    } else {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['frontend']
-            = \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class;
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
-            = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['options']);
+if (0 === (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
+    foreach ($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] as $configurationName => $configuration) {
+        if (is_a($configuration['backend'], \TYPO3\CMS\Core\Cache\Backend\PhpCapableBackendInterface::class, true)) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
+                = \TYPO3\CMS\Core\Cache\Backend\NullBackend::class;
+        } elseif (is_a($configuration['frontend'], \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class, true)) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
+                = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
+            unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['options']);
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['frontend']
+                = \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class;
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['backend']
+                = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
+            unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$configurationName]['options']);
+        }
     }
 }


### PR DESCRIPTION
The TYPO3 caching framework is not used by the Install Tool
except for the database compare function, which will create
tables according to the caching framework configuration.
It all caches are disabled the Install Tool wants to drop these
caching tables.

This fix disables the uncaching for Install Tool requests, therefor
caches are enabled and the cf_* tables won't get dropped.

resolves #13